### PR TITLE
Add missing cstdint header

### DIFF
--- a/addon/node_editor/imgui_json.h
+++ b/addon/node_editor/imgui_json.h
@@ -6,6 +6,7 @@
 # include <vector>
 # include <map>
 # include <cstddef>
+# include <cstdint>
 # include <algorithm>
 # include <sstream>
 


### PR DESCRIPTION
std::intptr_t is not available without - does not compile with GCC 13